### PR TITLE
Render clean up

### DIFF
--- a/frontend/src/classes/drawUtil.js
+++ b/frontend/src/classes/drawUtil.js
@@ -58,6 +58,7 @@ function _drawShip(ctx, player) {
             img.src = yellowShip;
         }
     }
+    console.log(player.color);
     ctx.save();
     ctx.translate(player.pos.x, player.pos.y);
     ctx.rotate(rotateDir);

--- a/frontend/src/classes/drawUtil.js
+++ b/frontend/src/classes/drawUtil.js
@@ -1,0 +1,124 @@
+import boomImg from "../style/images/boom.png";
+import hazard1 from "../style/images/asteroid1.png";
+// import xplo from "../style/images/explosion3.png";
+
+import redBlast from "../style/images/redblast.png";
+import blueBlast from "../style/images/blueblast.png";
+import greenBlast from "../style/images/greenblast.png";
+import yellowBlast from "../style/images/yellowblast.png";
+
+const redShip = require("../style/images/redshipfire.png");
+const blueShip = require("../style/images/blueshipfire.png");
+const greenShip = require("../style/images/greenshipfire.png");
+const yellowShip = require("../style/images/yellowshipfire.png");
+
+const redGod = require("../style/images/redgod.png");
+const blueGod = require("../style/images/bluegod.png");
+const greenGod = require("../style/images/greengod.png");
+const yellowGod = require("../style/images/yellowgod.png");
+
+export const drawPlayer = (ctx, player) => {
+    if (player.health <= 0) {
+        let boom = new Image();
+        boom.src = boomImg;
+        ctx.drawImage(boom, player.pos.x - 17, player.pos.y - 17, 25, 25);
+    } else {
+        _drawShip(ctx, player);
+    }
+}
+
+function _drawShip(ctx, player) {
+    let img = new Image();
+    let rotateDir = Math.atan(player.dir.y / player.dir.x);
+    if (player.dir.x < 0) {
+        rotateDir = rotateDir + Math.PI;
+    }
+    if (player.color === "RED") {
+        if (player.invuln > 0) {
+            img.src = redGod;
+        } else {
+            img.src = redShip;
+        }
+    } else if (player.color === "BLUE") {
+        if (player.invuln > 0) {
+            img.src = blueGod;
+        } else {
+            img.src = blueShip;
+        }
+    } else if (player.color === "GREEN") {
+        if (player.invuln > 0) {
+            img.src = greenGod;
+        } else {
+            img.src = greenShip;
+        }
+    } else if (player.color === "YELLOW") {
+        if (player.invuln > 0) {
+            img.src = yellowGod;
+        } else {
+            img.src = yellowShip;
+        }
+    }
+    ctx.save();
+    ctx.translate(player.pos.x, player.pos.y);
+    ctx.rotate(rotateDir);
+    ctx.translate(-player.pos.x, -player.pos.y);
+    ctx.drawImage(
+        img,
+        player.pos.x - player.radius - 1,
+        player.pos.y - player.radius - 3,
+        player.radius * 2 + 5,
+        player.radius * 2 + 5
+    );
+    ctx.restore();
+}
+
+export const drawHazard = (ctx, hazard) => {
+    if (hazard.health <= 0) {
+        let boom = new Image();
+        boom.src = boomImg;
+        ctx.drawImage(boom, hazard.pos.x, hazard.pos.y, 5, 5);
+    } else {
+        _drawHazard(ctx, hazard);
+    }
+}
+
+function _drawHazard(ctx, hazard) {
+    let img = new Image();
+    let rotateDir = Math.atan(hazard.dir.y / hazard.dir.x);
+    if (hazard.dir.x < 0) {
+        rotateDir = rotateDir + Math.PI;
+    }
+    img.src = hazard1;
+    ctx.save();
+    ctx.translate(hazard.pos.x, hazard.pos.y);
+    ctx.rotate(rotateDir);
+    ctx.translate(-hazard.pos.x, -hazard.pos.y);
+    ctx.drawImage(img, hazard.pos.x - hazard.radius, hazard.pos.y - hazard.radius, hazard.radius * 2, hazard.radius * 2);
+    ctx.restore();
+}
+
+export const drawBullet = (ctx, bullet) => {
+    let img = new Image();
+    let rotateDir = Math.atan(bullet.vel.y / bullet.vel.x);
+
+    if (bullet.vel.x < 0) {
+        rotateDir = rotateDir + Math.PI;
+    }
+
+    if (bullet.color === 'RED') {
+        img.src = redBlast;
+    } else if (bullet.color === 'BLUE') {
+        img.src = blueBlast;
+    } else if (bullet.color === 'GREEN') {
+        img.src = greenBlast;
+    } else if (bullet.color === 'YELLOW') {
+        img.src = yellowBlast;
+    }
+
+    ctx.save();
+    ctx.translate(bullet.pos.x, bullet.pos.y);
+    ctx.rotate(rotateDir);
+    ctx.translate(-bullet.pos.x, -bullet.pos.y);
+    ctx.drawImage(img, bullet.pos.x - (bullet.radius * 1.5), bullet.pos.y - bullet.radius, bullet.radius * 2.5, bullet.radius * 2);
+    ctx.restore();
+}

--- a/frontend/src/components/game.jsx
+++ b/frontend/src/components/game.jsx
@@ -6,6 +6,7 @@ import Hazard from "../classes/hazard";
 import Bullet from "../classes/bullet";
 import PlayerListItem from "./player_list_item";
 import backSound from "../style/sounds/InterplanetaryOdyssey.ogg";
+import * as DrawUtil from '../classes/drawUtil';
 
 let socketURL = "http://localhost:5000";
 
@@ -98,7 +99,7 @@ class Canvas extends React.Component {
 			});
 		});
 
-		socket.on("newPosition", data => {
+		socket.on("gameUpdate", data => {
 			this.setState({ time: Math.ceil(data.timer), round: data.rounds - 1, gameStatus: data.gameState});
 			if (data.rounds === 0) {
 				this.props.history.push({
@@ -109,6 +110,9 @@ class Canvas extends React.Component {
 					)[0]
 				});
 			}
+		});
+
+		socket.on("playerPositions", data => {
 			this.players = [];
 			let players = data.players;
 			players.forEach(player => {
@@ -116,6 +120,9 @@ class Canvas extends React.Component {
 				p = Object.assign(p, player);
 				this.players.push(p);
 			});
+		});
+
+		socket.on("hazardPositions", data => {
 			this.hazards = [];
 			let hazards = data.hazards;
 			hazards.forEach(hazard => {
@@ -123,6 +130,9 @@ class Canvas extends React.Component {
 				h = Object.assign(h, hazard);
 				this.hazards.push(h);
 			});
+		});
+
+		socket.on("bulletPositions", data => {
 			this.bullets = [];
 			let bullets = data.bullets;
 
@@ -144,16 +154,19 @@ class Canvas extends React.Component {
 			can1Ctx.rect(0, 0, 1600, 900);
 			can1Ctx.fillStyle = "black";
 			can1Ctx.fill();
-			let objects = this.players.concat(this.hazards).concat(this.bullets);
-			objects.forEach(object => {
-				if (object instanceof Player) {
-					object.draw(can1Ctx, object);
-				} else if (object instanceof Bullet) {
-					object.draw(can1Ctx, object.color);
-				} else {
-					object.draw(can1Ctx);
-				}
-			});
+			this.players.forEach(player => DrawUtil.drawPlayer(can1Ctx, player));
+			this.hazards.forEach(hazard => DrawUtil.drawHazard(can1Ctx, hazard));
+			this.bullets.forEach(bullet => DrawUtil.drawBullet(can1Ctx, bullet));
+			// let objects = this.bullets;
+			// objects.forEach(object => {
+			// 	if (object instanceof Player) {
+			// 		object.draw(can1Ctx, object);
+			// 	} else if (object instanceof Bullet) {
+			// 		object.draw(can1Ctx, object.color);
+			// 	} else {
+			// 		object.draw(can1Ctx);
+			// 	}
+			// });
 			requestAnimationFrame(this.drawObj);
 		}
 		// can2Ctx.drawImage(can1, 0, 0);

--- a/frontend/src/components/game.jsx
+++ b/frontend/src/components/game.jsx
@@ -113,34 +113,15 @@ class Canvas extends React.Component {
 		});
 
 		socket.on("playerPositions", data => {
-			this.players = [];
-			let players = data.players;
-			players.forEach(player => {
-				let p = new Player();
-				p = Object.assign(p, player);
-				this.players.push(p);
-			});
+			this.players = data.players;
 		});
 
 		socket.on("hazardPositions", data => {
-			this.hazards = [];
-			let hazards = data.hazards;
-			hazards.forEach(hazard => {
-				let h = new Hazard();
-				h = Object.assign(h, hazard);
-				this.hazards.push(h);
-			});
+			this.hazards = data.hazards;
 		});
 
 		socket.on("bulletPositions", data => {
-			this.bullets = [];
-			let bullets = data.bullets;
-
-			bullets.forEach(bullet => {
-				let b = new Bullet();
-				b = Object.assign(b, bullet);
-				this.bullets.push(b);
-			});
+			this.bullets = data.bullets;
 		});
 	};
 

--- a/frontend/src/components/game.jsx
+++ b/frontend/src/components/game.jsx
@@ -154,9 +154,9 @@ class Canvas extends React.Component {
 			can1Ctx.rect(0, 0, 1600, 900);
 			can1Ctx.fillStyle = "black";
 			can1Ctx.fill();
+			this.bullets.forEach(bullet => DrawUtil.drawBullet(can1Ctx, bullet));
 			this.players.forEach(player => DrawUtil.drawPlayer(can1Ctx, player));
 			this.hazards.forEach(hazard => DrawUtil.drawHazard(can1Ctx, hazard));
-			this.bullets.forEach(bullet => DrawUtil.drawBullet(can1Ctx, bullet));
 			// let objects = this.bullets;
 			// objects.forEach(object => {
 			// 	if (object instanceof Player) {

--- a/frontend/src/components/game.jsx
+++ b/frontend/src/components/game.jsx
@@ -378,13 +378,14 @@ class Canvas extends React.Component {
 		switch (this.state.gameStatus) {
 			case "WAITING":
 				return (
-					<div>
+					<div class='instructions'>
 						<h1>INSTRUCTIONS</h1>
 						<ul>
 							<li><span className='key'>W</span> : Move</li>
 							<li><span className='key'>A</span>/<span className='key'>D</span> : Turn</li>
 							<li><span className='key'>SPACE</span> : Shoot</li>
 						</ul>
+						<div><p>Game can be started once</p><p>all players are ready.</p></div>
 					</div>
 				);
 			case "STARTING":

--- a/frontend/src/style/stylesheets/game.css
+++ b/frontend/src/style/stylesheets/game.css
@@ -260,3 +260,17 @@
     outline: none;
     background: white;
 }
+
+.instructions {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+
+.instructions div {
+    margin-top: 2em;
+}
+
+.instructions p {
+    line-height: 1.5em;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5398,11 +5398,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5415,15 +5417,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5526,7 +5531,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5536,6 +5542,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5548,17 +5555,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5575,6 +5585,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5647,7 +5658,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5657,6 +5669,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5762,6 +5775,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/src/classes/game.js
+++ b/src/classes/game.js
@@ -194,7 +194,8 @@ class Game {
 					pos: player.pos,
 					dir: player.dir,
 					invuln: player.invuln,
-					color: player.color
+					color: player.color,
+					radius: player.radius
 				}))
 			});
 			// emite hazard positions
@@ -296,7 +297,7 @@ class Game {
 
 	initRound() {
 		this.populateHazards();
-		hazardCount += 2;
+		hazardCount++;
 		this.bullets = [];
 		// Object.values(this.players).forEach(player => {
 		// 	player.applyPowerUp(PowerUps.shotgun);


### PR DESCRIPTION
- Separated position updates into 4 different emits to improve latency
- Added drawUtil with methods to render each type of game object to use instead of instantiating new objects each render cycle
- Added text to tell players to ready up (apparently this was not obvious when game wasn't starting)
- Reduced round timers to 30s when Demo user is present
- Reduced hazard increment to 1 instead of 2 per round